### PR TITLE
add support for empty nd-array syntax

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -2725,6 +2725,12 @@ function parse_cat(ps::ParseState, closer, end_is_symbol)
     if k == closer
         # []  ==>  (vect)
         return parse_vect(ps, closer)
+    elseif k == K";"
+        # [;;]      ==>  (ncat 2)
+        # [;; \n ]  ==>  (ncat 2)
+        n_semis, _ = parse_array_separator(ps)
+        bump_closing_token(ps, closer)
+        return (K"ncat", set_numeric_flags(n_semis))
     end
     mark = position(ps)
     parse_eq_star(ps)

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -2673,13 +2673,13 @@ end
 #   power of 0 for whitespace and negative numbers for other separators.
 #
 # FIXME: Error messages for mixed spaces and ;; delimiters
-function parse_array_separator(ps)
-    t = peek_token(ps)
+function parse_array_separator(ps; skip_newlines=false)
+    t = peek_token(ps; skip_newlines=skip_newlines)
     k = kind(t)
     if k == K";"
         n_semis = 1
         while true
-            bump(ps, TRIVIA_FLAG)
+            bump(ps, TRIVIA_FLAG; skip_newlines=skip_newlines)
             t = peek_token(ps)
             if kind(t) != K";" || t.had_whitespace
                 break
@@ -2722,17 +2722,18 @@ function parse_cat(ps::ParseState, closer, end_is_symbol)
                     whitespace_newline=false,
                     for_generator=true)
     k = peek(ps, skip_newlines=true)
+    mark = position(ps)
     if k == closer
         # []  ==>  (vect)
         return parse_vect(ps, closer)
     elseif k == K";"
         # [;;]      ==>  (ncat 2)
         # [;; \n ]  ==>  (ncat 2)
-        n_semis, _ = parse_array_separator(ps)
+        n_semis, _ = parse_array_separator(ps; skip_newlines=true)
         bump_closing_token(ps, closer)
+        min_supported_version(v"1.8", ps, mark, "empty multidimensional array syntax")
         return (K"ncat", set_numeric_flags(n_semis))
     end
-    mark = position(ps)
     parse_eq_star(ps)
     k = peek(ps, skip_newlines=true)
     if k == K"," || k == closer

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -633,6 +633,9 @@ tests = [
         # Column major
         ((v=v"1.7",), "[x ; y ;; z ; w ;;; a ; b ;; c ; d]")  =>
             "(ncat-3 (nrow-2 (nrow-1 x y) (nrow-1 z w)) (nrow-2 (nrow-1 a b) (nrow-1 c d)))"
+        # Empty nd arrays
+        ((v=v"1.8",), "[;;]")  =>  "(ncat-2)"
+        ((v=v"1.8",), "[\n  ;; \n ]")  =>  "(ncat-2)"
     ],
     JuliaSyntax.parse_string => [
         "\"a \$(x + y) b\""  =>  "(string \"a \" (call-i x + y) \" b\")"


### PR DESCRIPTION
What's still missing here is the correct compat check, since this is
only supported in Julia 1.8. I wasn't sure how to check for this in
`check_ncat_compat`.
