### PR TITLE
Compat for odd Exprs in long form anonymous functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,10 @@ parsing `key=val` pairs inside parentheses.
   or (b) all lines should be dedented only one character, as that's the
   matching prefix.
 
+* Parsing of anonymous function arguments is somewhat inconsistent.
+  `function (xs...) \n body end` parses the argument list as `(... xs)`, whereas
+  `function (x) \n body end` parses the argument list as `(tuple x)`.
+
 # Comparisons to other packages
 
 ### Official Julia compiler

--- a/src/syntax_tree.jl
+++ b/src/syntax_tree.jl
@@ -415,6 +415,16 @@ function _to_expr(node::SyntaxNode, iteration_spec=false)
             # Add block for source locations
             args[2] = Expr(:block, loc, args[2])
         end
+    elseif headsym == :function
+        if length(args) > 1 && Meta.isexpr(args[1], :tuple)
+            # Convert to weird Expr forms for long-form anonymous functions.
+            #
+            # (function (tuple (... xs)) body) ==> (function (... xs) body)
+            if length(args[1].args) == 1 && Meta.isexpr(args[1].args[1], :...)
+                # function (xs...) \n body end
+                args[1] = args[1].args[1]
+            end
+        end
     end
     if headsym == :inert || (headsym == :quote && length(args) == 1 &&
                  !(a1 = only(args); a1 isa Expr || a1 isa QuoteNode ||

--- a/test/parse_packages.jl
+++ b/test/parse_packages.jl
@@ -21,7 +21,7 @@ end
 
 end
 
-if VERSION < v"1.8" || haskey(ENV, "PARSE_STDLIB")
+if VERSION < v"1.8-DEV" || haskey(ENV, "PARSE_STDLIB")
 # TODO: Fix on 1.8
 
 @testset "Parse Julia stdlib at $(Sys.STDLIB)" begin

--- a/test/parse_packages.jl
+++ b/test/parse_packages.jl
@@ -20,8 +20,9 @@ base_tests_path = joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia", "test")
 end
 
 end
-if haskey(ENV, "PARSE_STDLIB")
-# TODO: Turn on by default
+
+if VERSION < v"1.8" || haskey(ENV, "PARSE_STDLIB")
+# TODO: Fix on 1.8
 
 @testset "Parse Julia stdlib at $(Sys.STDLIB)" begin
     for stdlib in readdir(Sys.STDLIB)

--- a/test/syntax_tree.jl
+++ b/test/syntax_tree.jl
@@ -24,4 +24,11 @@
                  Expr(:(=), Expr(:call, :f), :xs),
                  Expr(:block))
     end
+
+    @testset "Long form anonymous functions" begin
+        @test parseall(Expr, "function (xs...)\nbody end", rule=:statement) ==
+            Expr(:function,
+                 Expr(:..., :xs),
+                 Expr(:block, :body))
+    end
 end


### PR DESCRIPTION
The following construct is parsed oddly by the reference parser with the
tuple omitted from the argument list. Add a compatibility hack for that
during Expr conversion.

```julia
    function (xs...)
        body
    end
```

With this we now have compatible parsing for all of the stdlib, so turn
on this test by default.