### PR TITLE
Fixes for `;;` and spaces in array concatenation

### DIFF
--- a/src/green_tree.jl
+++ b/src/green_tree.jl
@@ -79,7 +79,7 @@ function _show_green_node(io, node, indent, pos, str, show_trivia)
     if is_leaf
         line = string(posstr, indent, summary(node))
     else
-        line = string(posstr, indent, '[', summary(node), "]")
+        line = string(posstr, indent, '[', summary(node), ']')
     end
     if !is_trivia(node) && is_leaf
         line = rpad(line, 40) * "✔"

--- a/src/parse_stream.jl
+++ b/src/parse_stream.jl
@@ -51,11 +51,11 @@ numeric_flags(head::SyntaxHead) = numeric_flags(flags(head))
 is_error(head::SyntaxHead)  = kind(head) == K"error"
 
 function Base.summary(head::SyntaxHead)
-    _kind_str(kind(head))
+    untokenize(head, unique=false, include_flag_suff=false)
 end
 
-function untokenize(head::SyntaxHead; include_flag_suff=true)
-    str = untokenize(kind(head))
+function untokenize(head::SyntaxHead; unique=true, include_flag_suff=true)
+    str = untokenize(kind(head); unique=unique)
     if is_dotted(head)
         str = "."*str
     end

--- a/src/tokens.jl
+++ b/src/tokens.jl
@@ -113,15 +113,17 @@ function is_whitespace(t)
     kind(t) in (K"Whitespace", K"NewlineWs")
 end
 
-function _kind_str(k::Kind)
-    _kind_to_str[k]
-end
-
 """
 Return the string representation of a token kind, or `nothing` if the kind
 represents a class of tokens like K"Identifier".
+
+When `unique=true` only return a string when the kind uniquely defines the
+corresponding input token, otherwise return `nothing`.  When `unique=false`,
+return the name of the kind.
+
+TODO: Replace `untokenize()` with `Base.string()`?
 """
-function untokenize(k::Kind)
-    get(_kind_to_str_unique, k, nothing)
+function untokenize(k::Kind; unique=true)
+    get(unique ? _kind_to_str_unique : _kind_to_str, k, nothing)
 end
 

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -625,9 +625,6 @@ tests = [
         "[x y]"  =>  "(hcat x y)"
         # Mismatched rows
         "[x y ; z]"  =>  "(vcat (row x y) z)"
-        # Double semicolon with spaces allowed (only) for line continuation
-        "[x y ;;\n z w]"  =>  "(hcat x y z w)"
-        # "[x y ;; z w]"  =>  "(hcat x y (error) z w)" # FIXME
         # Single elements in rows
         ((v=v"1.7",), "[x ; y ;; z ]")  =>  "(ncat-2 (nrow-1 x y) z)"
         ((v=v"1.7",), "[x  y ;;; z ]")  =>  "(ncat-3 (row x y) z)"
@@ -638,6 +635,24 @@ tests = [
         # Column major
         ((v=v"1.7",), "[x ; y ;; z ; w ;;; a ; b ;; c ; d]")  =>
             "(ncat-3 (nrow-2 (nrow-1 x y) (nrow-1 z w)) (nrow-2 (nrow-1 a b) (nrow-1 c d)))"
+        # Array separators
+        # Newlines before semicolons are not significant
+        "[a \n ;]"  =>  "(vcat a)"
+        # Newlines after semicolons are not significant
+        "[a ; \n]"  =>  "(vcat a)"
+        "[a ; \n\n b]"  =>  "(vcat a b)"
+        ((v=v"1.7",), "[a ;; \n b]")  =>  "(ncat-2 a b)"
+        # In hcat with spaces as separators, `;;` is a line
+        # continuation character
+        ((v=v"1.7",), "[a b ;; \n c]")  =>  "(hcat a b c)"
+        ((v=v"1.7",), "[a b \n ;; c]")  =>  "(ncat-2 (row a b (error-t)) c)"
+        # Can't mix spaces and multiple ;'s
+        ((v=v"1.7",), "[a b ;; c]")  =>  "(ncat-2 (row a b (error-t)) c)"
+        # Treat a linebreak prior to a value as a semicolon (ie, separator for
+        # the first dimension) if no previous semicolons observed
+        "[a \n b]"  =>  "(vcat a b)"
+        # Can't mix multiple ;'s and spaces
+        ((v=v"1.7",), "[a ;; b c]")  =>  "(ncat-2 a (row b (error-t) c))"
         # Empty nd arrays
         ((v=v"1.8",), "[;]")   =>  "(ncat-1)"
         ((v=v"1.8",), "[;;]")  =>  "(ncat-2)"


### PR DESCRIPTION
* Dectect whether array concatenation is either column-major or
  row-major in the first and second dimesions. Report errors for mixed
  orderings.
* Treat ;; as line continuation when used in hcat
* Treat newlines as insignificant when mixed with semicolons as
  separators.