### PR TITLE
Fix parser comparison tool. stdlib now parses for 1.6 - 1.8

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -2677,7 +2677,6 @@ end
 #   tightest:  ... < `;;;` < `;;` < `;`,`\n` < whitespace. We choose binding
 #   power of 0 for whitespace and negative numbers for other separators.
 #
-# FIXME: Error messages for mixed spaces and ;; delimiters
 function parse_array_separator(ps, array_order)
     sep_mismatch_err = "cannot mix space and ;; separators in an array expression, except to wrap a line"
     mark = position(ps)

--- a/test/parse_packages.jl
+++ b/test/parse_packages.jl
@@ -21,9 +21,6 @@ end
 
 end
 
-if VERSION < v"1.8-DEV" || haskey(ENV, "PARSE_STDLIB")
-# TODO: Fix on 1.8
-
 @testset "Parse Julia stdlib at $(Sys.STDLIB)" begin
     for stdlib in readdir(Sys.STDLIB)
         fulldir = joinpath(Sys.STDLIB, stdlib)
@@ -33,6 +30,4 @@ if VERSION < v"1.8-DEV" || haskey(ENV, "PARSE_STDLIB")
             end
         end
     end
-end
-
 end


### PR DESCRIPTION
It turns out that SparseArrays has some unused .jl files in the tests
with broken syntax in 1.8 dev. Fix the JuliaSyntax parser comparison
tool to ignore these cases.