### PR TITLE
get rid of the `TokenError` field in `Token`

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ name of compatibility, perhaps with a warning.)
   broken-looking AST like `(macrocall (. A (quote (. B @x))))`.  It should
   probably be rejected.
 * Operator prefix call syntax doesn't work in the cases like `+(a;b,c)` where
-  keyword parameters are separated by commas. A tuple is produced instead. 
+  keyword parameters are separated by commas. A tuple is produced instead.
 * `const` and `global` allow chained assignment, but the right hand side is not
   constant. `a` const here but not `b`.
   ```
@@ -698,7 +698,7 @@ interface. Could we have `Expr2` wrap `SyntaxNode`?
   tree library (rowan) for representing of a non-rust toy language is here
   https://dev.to/cad97/lossless-syntax-trees-280c
 
-Not all the design decisions in `rust-analyzer` are finalized but the 
+Not all the design decisions in `rust-analyzer` are finalized but the
 [architecture document](https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/dev/architecture.md)
 is a fantastic source of design inspiration.
 
@@ -772,7 +772,7 @@ The tree datastructure design here is tricky:
     parentheses in `2*(x + y)` and the explicit vs implicit multiplication
     symbol in `2*x` vs `2x`.
 
-2. There's various type of *analyses* 
+2. There's various type of *analyses*
 - There's many useful ways to augment a syntax tree depending on use case.
 - Analysis algorithms should be able to act on any tree type, ignoring
   but carrying augmentations which they don't know about.
@@ -983,4 +983,3 @@ indentation from the syntax tree?  Source formatting involves a big pile of
 heuristics to get something which "looks nice"... and ML systems have become
 very good at heuristics. Also, we've got huge piles of training data — just
 choose some high quality, tastefully hand-formatted libraries.
-

--- a/Tokenize/benchmark/lex_base.jl
+++ b/Tokenize/benchmark/lex_base.jl
@@ -18,7 +18,7 @@ function speed_test()
                     while !Tokenize.Lexers.eof(l)
                         t = Tokenize.Lexers.next_token(l)
                         tot_tokens += 1
-                        if t.kind == Tokens.ERROR
+                        if Tokens.iserror(t.kind)
                             tot_errors += 1
                         end
                     end

--- a/Tokenize/src/token.jl
+++ b/Tokenize/src/token.jl
@@ -10,7 +10,7 @@ include("token_kinds.jl")
 iskeyword(k::Kind) = begin_keywords < k < end_keywords
 isliteral(k::Kind) = begin_literal < k < end_literal
 isoperator(k::Kind) = begin_ops < k < end_ops
-
+iserror(k::Kind) = begin_errors < k < end_errors
 iscontextualkeyword(k::Kind) = begin_contextual_keywords < k < end_contextual_keywords
 
 function iswordoperator(k::Kind)
@@ -32,25 +32,14 @@ function _add_kws()
 end
 _add_kws()
 
-# TODO: more
-@enum(TokenError,
-    NO_ERR,
-    EOF_MULTICOMMENT,
-    EOF_CHAR,
-    INVALID_NUMERIC_CONSTANT,
-    INVALID_OPERATOR,
-    INVALID_INTERPOLATION_TERMINATOR,
-    UNKNOWN,
-)
-
 # Error kind => description
-TOKEN_ERROR_DESCRIPTION = Dict{TokenError, String}(
+TOKEN_ERROR_DESCRIPTION = Dict{Kind, String}(
     EOF_MULTICOMMENT => "unterminated multi-line comment #= ... =#",
     EOF_CHAR => "unterminated character literal",
     INVALID_NUMERIC_CONSTANT => "invalid numeric constant",
     INVALID_OPERATOR => "invalid operator",
     INVALID_INTERPOLATION_TERMINATOR => "interpolated variable ends with invalid character; use `\$(...)` instead",
-    UNKNOWN => "unknown",
+    ERROR => "unknown error",
 )
 
 struct Token
@@ -58,14 +47,13 @@ struct Token
     # Offsets into a string or buffer
     startbyte::Int # The byte where the token start in the buffer
     endbyte::Int # The byte where the token ended in the buffer
-    token_error::TokenError
     dotop::Bool
     suffix::Bool
 end
 function Token(kind::Kind, startbyte::Int, endbyte::Int)
-    Token(kind, startbyte, endbyte, NO_ERR, false, false)
+    Token(kind, startbyte, endbyte, false, false)
 end
-Token() = Token(ERROR, 0, 0, UNKNOWN, false, false)
+Token() = Token(ERROR, 0, 0, false, false)
 
 
 const _EMPTY_RAWTOKEN = Token()
@@ -74,6 +62,7 @@ EMPTY_TOKEN(::Type{Token}) = _EMPTY_RAWTOKEN
 function kind(t::Token)
     isoperator(t.kind) && return OP
     iskeyword(t.kind) && return KEYWORD
+    iserror(t.kind) && return ERROR
     return t.kind
 end
 exactkind(t::Token) = t.kind

--- a/Tokenize/src/token_kinds.jl
+++ b/Tokenize/src/token_kinds.jl
@@ -1,13 +1,21 @@
 @enum(Kind,
     NONE,      # Placeholder; never emitted by lexer
     ENDMARKER, # EOF
-    ERROR,
     COMMENT, # aadsdsa, #= fdsf #=
     WHITESPACE, # '\n   \t'
     IDENTIFIER, # foo, Σxx
     AT_SIGN, # @
     COMMA, #,
     SEMICOLON, # ;
+
+    begin_errors,
+        EOF_MULTICOMMENT,
+        EOF_CHAR,
+        INVALID_NUMERIC_CONSTANT,
+        INVALID_OPERATOR,
+        INVALID_INTERPOLATION_TERMINATOR,
+        ERROR,
+    end_errors,
 
     begin_keywords,
         KEYWORD, # general

--- a/src/parse_stream.jl
+++ b/src/parse_stream.jl
@@ -55,7 +55,7 @@ function Base.summary(head::SyntaxHead)
 end
 
 function untokenize(head::SyntaxHead; unique=true, include_flag_suff=true)
-    str = untokenize(kind(head); unique=unique)
+    str = is_error(kind(head)) ? "error" : untokenize(kind(head); unique=unique)
     if is_dotted(head)
         str = "."*str
     end

--- a/src/tokens.jl
+++ b/src/tokens.jl
@@ -43,6 +43,7 @@ kind(raw::TzTokens.Token) = TzTokens.exactkind(raw)
 # Some renaming for naming consistency
 is_literal(k) = TzTokens.isliteral(kind(k))
 is_keyword(k) = TzTokens.iskeyword(kind(k))
+is_error(k) = TzTokens.iserror(kind(k))
 is_contextual_keyword(k) = TzTokens.iscontextualkeyword(kind(k))
 is_operator(k) = TzTokens.isoperator(kind(k))
 is_word_operator(k) = TzTokens.iswordoperator(kind(k))


### PR DESCRIPTION
It is very rare for tokens to be errors but we still need to pay the cost of the `TokenError` field every time. This PR just moves the `TokenError` into a `Kind` and has a function `iserror` to check if the kind is of an error type.

Made on top of https://github.com/c42f/JuliaSyntax.jl/pull/16