### PR TITLE
Optimization and cleanup in parse stream

### DIFF
--- a/Tokenize/src/lexer.jl
+++ b/Tokenize/src/lexer.jl
@@ -524,7 +524,7 @@ function lex_comment(l::Lexer, doemit=true)
         while true
             pc = peekchar(l)
             if pc == '\n' || eof(pc)
-                return doemit ? emit(l, Tokens.COMMENT) : EMPTY_TOKEN(token_type(l))
+                return doemit ? emit(l, Tokens.COMMENT) : EMPTY_TOKEN
             end
             readchar(l)
         end
@@ -534,7 +534,7 @@ function lex_comment(l::Lexer, doemit=true)
         n_start, n_end = 1, 0
         while true
             if eof(c)
-                return doemit ? emit_error(l, Tokens.EOF_MULTICOMMENT) : EMPTY_TOKEN(token_type(l))
+                return doemit ? emit_error(l, Tokens.EOF_MULTICOMMENT) : EMPTY_TOKEN
             end
             nc = readchar(l)
             if c == '#' && nc == '='
@@ -543,7 +543,7 @@ function lex_comment(l::Lexer, doemit=true)
                 n_end += 1
             end
             if n_start == n_end
-                return doemit ? emit(l, Tokens.COMMENT) : EMPTY_TOKEN(token_type(l))
+                return doemit ? emit(l, Tokens.COMMENT) : EMPTY_TOKEN
             end
             pc = c
             c = nc
@@ -852,25 +852,25 @@ function lex_prime(l, doemit = true)
     else
         if accept(l, '\'')
             if accept(l, '\'')
-                return doemit ? emit(l, Tokens.CHAR) : EMPTY_TOKEN(token_type(l))
+                return doemit ? emit(l, Tokens.CHAR) : EMPTY_TOKEN
             else
                 # Empty char literal
                 # Arguably this should be an error here, but we generally
                 # look at the contents of the char literal in the parser,
                 # so we defer erroring until there.
-                return doemit ? emit(l, Tokens.CHAR) : EMPTY_TOKEN(token_type(l))
+                return doemit ? emit(l, Tokens.CHAR) : EMPTY_TOKEN
             end
         end
         while true
             c = readchar(l)
             if eof(c)
-                return doemit ? emit_error(l, Tokens.EOF_CHAR) : EMPTY_TOKEN(token_type(l))
+                return doemit ? emit_error(l, Tokens.EOF_CHAR) : EMPTY_TOKEN
             elseif c == '\\'
                 if eof(readchar(l))
-                    return doemit ? emit_error(l, Tokens.EOF_CHAR) : EMPTY_TOKEN(token_type(l))
+                    return doemit ? emit_error(l, Tokens.EOF_CHAR) : EMPTY_TOKEN
                 end
             elseif c == '\''
-                return doemit ? emit(l, Tokens.CHAR) : EMPTY_TOKEN(token_type(l))
+                return doemit ? emit(l, Tokens.CHAR) : EMPTY_TOKEN
             end
         end
     end

--- a/Tokenize/src/token.jl
+++ b/Tokenize/src/token.jl
@@ -67,9 +67,7 @@ function Token(kind::Kind, startbyte::Int, endbyte::Int)
 end
 Token() = Token(ERROR, 0, 0, UNKNOWN, false, false)
 
-
-const _EMPTY_RAWTOKEN = Token()
-EMPTY_TOKEN(::Type{Token}) = _EMPTY_RAWTOKEN
+const EMPTY_TOKEN = Token()
 
 function kind(t::Token)
     isoperator(t.kind) && return OP

--- a/Tokenize/src/token_kinds.jl
+++ b/Tokenize/src/token_kinds.jl
@@ -1,4 +1,4 @@
-@enum(Kind,
+@enum(Kind::UInt16,
     NONE,      # Placeholder; never emitted by lexer
     ENDMARKER, # EOF
     ERROR,

--- a/src/green_tree.jl
+++ b/src/green_tree.jl
@@ -63,10 +63,6 @@ children(node::GreenNode)    = node.args
 span(node::GreenNode)        = node.span
 head(node::GreenNode)        = node.head
 
-# Predicates
-is_trivia(node::GreenNode) = is_trivia(node.head)
-is_error(node::GreenNode)  = is_error(node.head)
-
 Base.summary(node::GreenNode) = summary(node.head)
 
 # Pretty printing

--- a/src/parse_stream.jl
+++ b/src/parse_stream.jl
@@ -85,12 +85,11 @@ struct SyntaxToken
     is_dotted::Bool
     is_suffixed::Bool
     had_whitespace::Bool
-    had_newline::Bool
 end
 
-function SyntaxToken(raw::Token, had_whitespace, had_newline)
+function SyntaxToken(raw::Token, had_whitespace)
     SyntaxToken(raw.kind, raw.startbyte + 1, raw.endbyte + 1, raw.dotop, raw.suffix,
-                had_whitespace, had_newline)
+                had_whitespace)
 end
 
 function Base.show(io::IO, tok::SyntaxToken)
@@ -255,15 +254,12 @@ end
 # but this is not a big problem.
 function _buffer_lookahead_tokens(stream::ParseStream)
     had_whitespace = false
-    had_newline    = false
     while true
         raw = Tokenize.Lexers.next_token(stream.lexer)
         k = TzTokens.exactkind(raw)
         was_whitespace = k in (K"Whitespace", K"Comment", K"NewlineWs")
-        was_newline    = k == K"NewlineWs"
         had_whitespace |= was_whitespace
-        had_newline    |= was_newline
-        push!(stream.lookahead, SyntaxToken(raw, had_whitespace, had_newline))
+        push!(stream.lookahead, SyntaxToken(raw, had_whitespace))
         if !was_whitespace
             break
         end

--- a/src/parse_stream.jl
+++ b/src/parse_stream.jl
@@ -325,7 +325,7 @@ end
     # unrolled optimized version for that fast path. Empirically it seems we
     # only hit the slow path about 5% of the time here.
     i = stream.lookahead_index
-    if n == 1 && i+1 <= length(stream.lookahead)
+    @inbounds if n == 1 && i+1 <= length(stream.lookahead)
         if skip_newlines
             k = kind(stream.lookahead[i])
             if !(k == K"Whitespace" || k == K"Comment" || k == K"NewlineWs")
@@ -364,7 +364,7 @@ end
             end
             _buffer_lookahead_tokens(stream.lexer, stream.lookahead)
         end
-        k = kind(stream.lookahead[i])
+        k = @inbounds kind(stream.lookahead[i])
         if !((k == K"Whitespace" || k == K"Comment") ||
              (k == K"NewlineWs" && skip_newlines))
             if n == 1
@@ -409,7 +409,7 @@ function peek_token(stream::ParseStream, n::Integer=1;
     if !skip_whitespace
         i = stream.lookahead_index
     end
-    return stream.lookahead[i]
+    return @inbounds stream.lookahead[i]
 end
 
 function _peek_behind_fields(ranges, i)

--- a/src/parse_stream.jl
+++ b/src/parse_stream.jl
@@ -294,15 +294,16 @@ function _lookahead_index(stream::ParseStream, n::Integer, skip_newlines::Bool)
 end
 
 """
-    peek(stream [, n=1])
+    peek(stream [, n=1]; skip_newlines=false)
 
 Look ahead in the stream `n` tokens, returning the token kind. Comments and
 non-newline whitespace are skipped automatically. Whitespace containing a
 single newline is returned as kind `K"NewlineWs"` unless `skip_newlines` is
 true.
 """
-function Base.peek(stream::ParseStream, n::Integer=1; skip_newlines::Bool=false)
-    kind(peek_token(stream, n; skip_newlines=skip_newlines))
+function Base.peek(stream::ParseStream, n::Integer=1;
+                   skip_newlines::Bool=false, skip_whitespace=true)
+    kind(peek_token(stream, n; skip_newlines=skip_newlines, skip_whitespace=skip_whitespace))
 end
 
 """
@@ -310,12 +311,17 @@ end
 
 Like `peek`, but return the full token information rather than just the kind.
 """
-function peek_token(stream::ParseStream, n::Integer=1; skip_newlines=false)
+function peek_token(stream::ParseStream, n::Integer=1;
+                    skip_newlines=false, skip_whitespace=true)
     stream.peek_count += 1
     if stream.peek_count > 100_000
         error("The parser seems stuck at byte $(stream.next_byte)")
     end
-    stream.lookahead[_lookahead_index(stream, n, skip_newlines)]
+    i = _lookahead_index(stream, n, skip_newlines)
+    if !skip_whitespace
+        i = 1
+    end
+    return stream.lookahead[i]
 end
 
 function _peek_behind_fields(ranges, i)

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -1405,7 +1405,6 @@ function parse_call_chain(ps::ParseState, mark, is_macrocall=false)
                 # A.@foo a b    ==> (macrocall (. A (quote @foo)) a b)
                 # @A.foo a b    ==> (macrocall (. A (quote @foo)) a b)
                 n_args = parse_space_separated_exprs(ps)
-                # TODO: Introduce K"doc" to make this hack less awful.
                 is_doc_macro = peek_behind(ps, macro_name_position).orig_kind == K"doc"
                 if is_doc_macro && n_args == 1
                     # Parse extended @doc args on next line

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -825,6 +825,7 @@ function parse_range(ps::ParseState)
             end
             n_colons += 1
             bump(ps, n_colons == 1 ? EMPTY_FLAGS : TRIVIA_FLAG)
+            had_newline = peek(ps, skip_newlines=false) == K"NewlineWs"
             t = peek_token(ps)
             if is_closing_token(ps, kind(t))
                 # 1: }    ==>  (call-i 1 : (error))
@@ -835,7 +836,7 @@ function parse_range(ps::ParseState)
                 emit_diagnostic(ps, error="found unexpected closing token")
                 return
             end
-            if t.had_newline
+            if had_newline
                 # Error message for people coming from python
                 # 1:\n2 ==> (call-i 1 : (error))
                 emit_diagnostic(ps, whitespace=true,

--- a/src/parser_api.jl
+++ b/src/parser_api.jl
@@ -152,7 +152,7 @@ function parseall(::Type{T}, input...; rule=:toplevel, version=VERSION,
     end
     parse(stream; rule=rule)
     if (ignore_trivia  && peek(stream, skip_newlines=true) != K"EndMarker") ||
-       (!ignore_trivia && (peek(stream); kind(first(stream.lookahead)) != K"EndMarker"))
+       (!ignore_trivia && (peek(stream, skip_newlines=false, skip_whitespace=false) != K"EndMarker"))
         emit_diagnostic(stream, error="unexpected text after parsing $rule")
     end
     if any_error(stream.diagnostics)

--- a/src/syntax_tree.jl
+++ b/src/syntax_tree.jl
@@ -96,13 +96,7 @@ function SyntaxNode(source::SourceFile, raw::GreenNode{SyntaxHead}, position::In
     end
 end
 
-is_error(node::SyntaxNode) = is_error(node.raw)
-is_trivia(node::SyntaxNode) = is_trivia(node.raw)
-has_flags(node::SyntaxNode, f) = has_flags(head(node), f)
-
 head(node::SyntaxNode) = head(node.raw)
-kind(node::SyntaxNode)  = kind(node.raw)
-flags(node::SyntaxNode) = flags(node.raw)
 
 haschildren(node::SyntaxNode) = !node.is_leaf
 children(node::SyntaxNode) = haschildren(node) ? node.val::Vector{SyntaxNode} : ()
@@ -189,10 +183,6 @@ end
 
 #-------------------------------------------------------------------------------
 # Tree utilities
-
-kind(node)  = kind(head(node))
-flags(node) = flags(head(node))
-is_infix(node) = is_infix(head(node))
 
 """
     child(node, i1, i2, ...)

--- a/test/parse_stream.jl
+++ b/test/parse_stream.jl
@@ -6,7 +6,7 @@
 using JuliaSyntax: ParseStream,
     peek, peek_token,
     bump, bump_trivia, bump_invisible,
-    emit, emit_diagnostic
+    emit, emit_diagnostic, TRIVIA_FLAG, INFIX_FLAG
 
 code = """
 for i = 1:10


### PR DESCRIPTION
This is a series of cleanup/optimization commits which

* Reduce the size of data structures in `ParseStream`
* Fix various JET warnings, particularly removing boxed closure captures and fixes to `EMPTY_TOKEN` in Tokenize
* Pool and reuse some data structures during parsing
* Better kind()/flags() API + compactify SyntaxToken flags
* Remove need for storing newline flag on SyntaxToken