### PR TITLE
Separate token output from internal nodes in ParseStream

### DIFF
--- a/src/green_tree.jl
+++ b/src/green_tree.jl
@@ -43,17 +43,22 @@ struct GreenNode{Head}
     args::Union{Tuple{},Vector{GreenNode{Head}}}
 end
 
+function GreenNode{Head}(head::Head, span::Integer) where {Head}
+    GreenNode{Head}(head, span, ())
+end
+
 function GreenNode(head::Head, span::Integer) where {Head}
     GreenNode{Head}(head, span, ())
 end
 
-function GreenNode(head::Head, span::Integer, args::Vector{GreenNode{Head}}) where {Head}
-    GreenNode{Head}(head, span, args)
+function GreenNode(head::Head, args) where {Head}
+    children = collect(GreenNode{Head}, args)
+    span = isempty(children) ? 0 : sum(x.span for x in children)
+    GreenNode{Head}(head, span, children)
 end
 
 function GreenNode(head::Head, args::GreenNode{Head}...) where {Head}
-    span = sum(x.span for x in args)
-    GreenNode{Head}(head, span, GreenNode{Head}[args...])
+    GreenNode{Head}(head, GreenNode{Head}[args...])
 end
 
 

--- a/src/parser_api.jl
+++ b/src/parser_api.jl
@@ -111,7 +111,7 @@ function parse(::Type{T}, io::IO;
     stream = ParseStream(io; version=version)
     parse(stream; rule=rule)
     tree = build_tree(T, stream; kws...)
-    seek(io, stream.next_byte-1)
+    seek(io, last_byte(stream))
     tree, stream.diagnostics
 end
 
@@ -122,7 +122,7 @@ function parse(::Type{T}, input...;
     stream = ParseStream(input...; version=version)
     parse(stream; rule=rule)
     tree = build_tree(T, stream; kws...)
-    tree, stream.diagnostics, stream.next_byte
+    tree, stream.diagnostics, last_byte(stream) + 1
 end
 
 
@@ -148,6 +148,7 @@ function parseall(::Type{T}, input...; rule=:toplevel, version=VERSION,
     stream = ParseStream(input...; version=version)
     if ignore_trivia && rule != :toplevel
         bump_trivia(stream, skip_newlines=true)
+        empty!(stream.tokens)
         empty!(stream.ranges)
     end
     parse(stream; rule=rule)

--- a/test/parser_api.jl
+++ b/test/parser_api.jl
@@ -15,7 +15,7 @@
             stream = ParseStream(pointer(code), 3)
             parse(stream, rule=:statement)
             @test JuliaSyntax.build_tree(Expr, stream) == :(x+y)
-            @test stream.next_byte == 4
+            @test JuliaSyntax.last_byte(stream) == 3
         end
 
         # SubString

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -59,7 +59,7 @@ function parsers_agree_on_file(filename)
             JuliaSyntax.remove_linenums!(ex) ==
             JuliaSyntax.remove_linenums!(fl_ex)
     catch exc
-        @error "Parsing failed" path exception=current_exceptions()
+        @error "Parsing failed" filename exception=current_exceptions()
         return false
     end
 end


### PR DESCRIPTION
This data rearrangement gives a cleaner separation between tokens (which
keep track of bytes in the source text) vs internal tree nodes (which
keep track of which tokens they cover). As a result it reduces the size
of the intermediate data structures.

As part of rewriting build_tree to use the new data structures it's also
become much faster and building the green tree no longer dominates the
parsing time (probably due to fixing some type stability issues).

With this change we're around 14x the speed of the flisp parser in producing
the green tree, and about 6x faster in producing `Expr` data structures.