### PR TITLE
Cleanup: put next_byte in token rather than first_byte

### DIFF
--- a/src/parser_api.jl
+++ b/src/parser_api.jl
@@ -148,8 +148,7 @@ function parseall(::Type{T}, input...; rule=:toplevel, version=VERSION,
     stream = ParseStream(input...; version=version)
     if ignore_trivia && rule != :toplevel
         bump_trivia(stream, skip_newlines=true)
-        empty!(stream.tokens)
-        empty!(stream.ranges)
+        empty!(stream)
     end
     parse(stream; rule=rule)
     if (ignore_trivia  && peek(stream, skip_newlines=true) != K"EndMarker") ||


### PR DESCRIPTION
While a bit counter-intuitive, this enables us to use an initial
sentinel token for recording the first byte of the first real token
which removes a bunch of special case hacks for computing the last byte
of the current output token.